### PR TITLE
Drop Singers

### DIFF
--- a/DiffSinger_colab_notebook.ipynb
+++ b/DiffSinger_colab_notebook.ipynb
@@ -12,8 +12,7 @@
         "FY40fGHEg9_i",
         "4sbU1aH5kGFE"
       ],
-      "gpuType": "T4",
-      "include_colab_link": true
+      "gpuType": "T4"
     },
     "kernelspec": {
       "name": "python3",
@@ -25,16 +24,6 @@
     "accelerator": "GPU"
   },
   "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/MLo7Ghinsan/DiffSinger_colab_notebook_MLo7/blob/main/DiffSinger_colab_notebook.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
     {
       "cell_type": "markdown",
       "metadata": {
@@ -806,6 +795,34 @@
       "metadata": {
         "id": "FY40fGHEg9_i"
       }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#@markdown # Drop Speakers from Model (Optional)\n",
+        "#@markdown ___\n",
+        "#@markdown <font size=\"-1.5\"> Use this to drop speakers from your model for distribution. You will need to do it for both acoustic and variance models.\n",
+        "\n",
+        "drop_model_path = '' #@param {type: \"string\"}\n",
+        "#@markdown <font size=\"-1.5\"> Type the ID of speakers you'd like to KEEP separated by commas. Ex: \"0,3,4\" <br>\n",
+        "#@markdown <font size=\"-1.5\"> Note: You can find the ID of speakers in the model by opening the ```spk_map.json``` file in the model folder.<br>\n",
+        "#@markdown <font size=\"-1.5\"> If you see ```{\"natural\": 0, \"power\": 1, \"silly\": 2}``` but only want to keep \"natural\" and \"power\", type ```0,1``` below.\n",
+        "retain_speakers = '' #@param {type: \"string\"}\n",
+        "#@markdown <font size=\"-1.5\"> If you don't know what this means, don't change it.\n",
+        "fill_embed = 'zeros' #@param ['zeros', 'random', 'mean', 'cyclic']\n",
+        "\n",
+        "drop_out_path = drop_model_path[:-5] + '_spk-dropped.ckpt'\n",
+        "\n",
+        "!python /content/DiffSinger/scripts/drop_spk.py {drop_model_path} {drop_out_path} --retain {retain_speakers} --fill {fill_embed}\n",
+        "\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "21ILzW4OEnh4",
+        "cellView": "form"
+      },
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",


### PR DESCRIPTION
added "drop speakers" section to "build onnx for OpenUTAU" part of the notebook, to remove any singers from the model easily.